### PR TITLE
Prevent zip path traversal in safe_unzip

### DIFF
--- a/tests/test_safe_unzip.py
+++ b/tests/test_safe_unzip.py
@@ -1,0 +1,37 @@
+import zipfile
+import pathlib
+import pytest
+import importlib.util
+
+
+_BUILD_SPEC = importlib.util.spec_from_file_location(
+    "build_module", pathlib.Path(__file__).resolve().parents[1] / "build.py"
+)
+build_module = importlib.util.module_from_spec(_BUILD_SPEC)
+_BUILD_SPEC.loader.exec_module(build_module)
+
+safe_unzip = build_module.safe_unzip
+BuildContext = build_module.BuildContext
+StyleStackError = build_module.StyleStackError
+
+
+def _make_context(tmp_path):
+    return BuildContext(source_path=tmp_path / "src", output_path=tmp_path / "out", temp_dir=tmp_path)
+
+
+def test_rejects_path_traversal(tmp_path):
+    zip_path = tmp_path / "traversal.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("../evil.txt", "malicious")
+    ctx = _make_context(tmp_path)
+    with pytest.raises(StyleStackError):
+        safe_unzip(zip_path, tmp_path / "dest", ctx)
+
+
+def test_rejects_absolute_path(tmp_path):
+    zip_path = tmp_path / "absolute.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("/etc/passwd", "malicious")
+    ctx = _make_context(tmp_path)
+    with pytest.raises(StyleStackError):
+        safe_unzip(zip_path, tmp_path / "dest", ctx)


### PR DESCRIPTION
## Summary
- validate each zip entry path in `safe_unzip` and manually extract files after verification
- add tests ensuring malicious archives trigger `StyleStackError`

## Testing
- `pytest tests/test_safe_unzip.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0cbb560488320896a1cf82a92e048