### PR TITLE
Add dependency cycle detection to extension schema validator

### DIFF
--- a/tests/test_dependency_cycles.py
+++ b/tests/test_dependency_cycles.py
@@ -1,0 +1,38 @@
+import pytest
+import jsonschema
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "tools"))
+from extension_schema_validator import ExtensionSchemaValidator
+
+
+def build_variable(var_id, deps=None):
+    return {
+        "id": var_id,
+        "type": "color",
+        "scope": "theme",
+        "xpath": "//a:clrScheme/a:accent1/a:srgbClr/@val",
+        "ooxml": {
+            "namespace": "http://schemas.openxmlformats.org/drawingml/2006/main",
+            "element": "srgbClr",
+            "attribute": "val",
+            "valueType": "schemeClr",
+        },
+        "defaultValue": "0066CC",
+        "dependencies": deps or [],
+    }
+
+
+def test_acyclic_dependencies():
+    variables = [build_variable("var1", ["var2"]), build_variable("var2")]
+    validator = ExtensionSchemaValidator()
+    results = validator.validate_variable_collection(variables)
+    assert all(r.is_valid for r in results)
+
+
+def test_cyclic_dependencies():
+    variables = [build_variable("var1", ["var2"]), build_variable("var2", ["var1"])]
+    validator = ExtensionSchemaValidator()
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        validator.validate_variable_collection(variables)


### PR DESCRIPTION
## Summary
- handle default ValidationResult state
- detect and report circular variable dependencies during cross validation
- add tests covering cyclic and acyclic variable dependency graphs

## Testing
- `pytest tests/test_dependency_cycles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cbb0a7ec8320ba6278bdc47e3dd2