### PR TITLE
Ensure reproducible ZIP compression

### DIFF
--- a/build.py
+++ b/build.py
@@ -137,10 +137,19 @@ def safe_unzip(src_zip: pathlib.Path, dst_dir: pathlib.Path, context: BuildConte
         )
 
 def safe_zip_dir(src_dir: pathlib.Path, out_zip: pathlib.Path, context: BuildContext):
-    """Create deterministic ZIP with error handling"""
+    """Create deterministic ZIP with reproducible compression and error handling.
+
+    Uses ``ZIP_DEFLATED`` compression with level 9 to guarantee deterministic
+    archives across runs.
+    """
     try:
         out_zip.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(out_zip, "w", compression=zipfile.ZIP_DEFLATED) as z:
+        with zipfile.ZipFile(
+            out_zip,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+            compresslevel=9,
+        ) as z:
             for p in sorted(src_dir.rglob("*")):
                 if p.is_file():
                     rel = p.relative_to(src_dir).as_posix()

--- a/tests/test_safe_zip_dir.py
+++ b/tests/test_safe_zip_dir.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Tests for the safe_zip_dir helper in build.py."""
+
+import hashlib
+import tempfile
+from pathlib import Path
+import unittest
+
+import build
+
+
+class TestSafeZipDirDeterminism(unittest.TestCase):
+    """Verify that safe_zip_dir produces deterministic archives."""
+
+    def test_repeated_runs_have_same_hash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            src_dir = tmp_path / "src"
+            src_dir.mkdir()
+            (src_dir / "file.txt").write_text("content")
+
+            out1 = tmp_path / "out1.zip"
+            out2 = tmp_path / "out2.zip"
+
+            context1 = build.BuildContext(src_dir, out1, tmp_path)
+            build.safe_zip_dir(src_dir, out1, context1)
+            hash1 = hashlib.sha256(out1.read_bytes()).hexdigest()
+
+            context2 = build.BuildContext(src_dir, out2, tmp_path)
+            build.safe_zip_dir(src_dir, out2, context2)
+            hash2 = hashlib.sha256(out2.read_bytes()).hexdigest()
+
+            self.assertEqual(hash1, hash2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use ZIP_DEFLATED level 9 in `safe_zip_dir` for reproducible archives
- document deterministic compression behavior
- test that repeated zips produce matching hashes

## Testing
- `python -m pytest tests/test_safe_zip_dir.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0cba09a3083209fadced30868f6db