### PR TITLE
Use logger for build import fallbacks

### DIFF
--- a/build.py
+++ b/build.py
@@ -17,6 +17,8 @@ from enum import Enum
 from lxml import etree as ET
 import click
 
+logger = logging.getLogger(__name__)
+
 # Import OOXML Extension Variable System components
 try:
     from tools.variable_resolver import VariableResolver
@@ -27,8 +29,10 @@ try:
     from tools.github_license_manager import GitHubLicenseManager, GitHubLicenseEnforcer, LicenseError
     EXTENSION_SYSTEM_AVAILABLE = True
 except ImportError as e:
-    print(f"Warning: Could not import OOXML Extension Variable System components: {e}")
-    print("Extension variable features will be disabled.")
+    logger.warning(
+        "Could not import OOXML Extension Variable System components: %s", e
+    )
+    logger.warning("Extension variable features will be disabled.")
     VariableResolver = None
     OOXMLProcessor = None
     ThemeResolver = None
@@ -45,8 +49,10 @@ try:
     from tools.json_patch_parser import ValidationLevel
     JSON_OOXML_ENGINE_AVAILABLE = True
 except ImportError as e:
-    print(f"Warning: Could not import JSON-to-OOXML Processing Engine: {e}")
-    print("JSON patch processing features will be disabled.")
+    logger.warning(
+        "Could not import JSON-to-OOXML Processing Engine: %s", e
+    )
+    logger.warning("JSON patch processing features will be disabled.")
     PatchExecutionEngine = None
     ExecutionMode = None
     ValidationLevel = None

--- a/tests/test_build_logger_warning.py
+++ b/tests/test_build_logger_warning.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Tests that missing modules trigger logger warnings in build.py."""
+
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+class TestMissingModuleWarnings(unittest.TestCase):
+    """Verify warnings are logged when optional modules are unavailable."""
+
+    def test_missing_modules_emit_warnings(self):
+        """Ensure missing optional modules emit warnings via logger."""
+        real_import = __import__
+
+        def mocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name.startswith("tools"):
+                raise ImportError("Mocked missing module")
+            return real_import(name, globals, locals, fromlist, level)
+
+        with patch("builtins.__import__", side_effect=mocked_import):
+            if "build" in sys.modules:
+                del sys.modules["build"]
+            with self.assertLogs("build", level="WARNING") as cm:
+                importlib.import_module("build")
+
+        joined = "\n".join(cm.output)
+        self.assertIn("Could not import OOXML Extension Variable System components", joined)
+        self.assertIn("Could not import JSON-to-OOXML Processing Engine", joined)
+
+        if "build" in sys.modules:
+            del sys.modules["build"]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace print statements in build.py import fallbacks with logger.warning
- add module-level logger configuration
- add test ensuring missing module warnings are logged

## Testing
- `pytest tests/test_build_logger_warning.py::TestMissingModuleWarnings::test_missing_modules_emit_warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cba735808320ae53e04b9df636a2