### PR TITLE
Add diff printing to OOXML analyzer

### DIFF
--- a/tests/test_ooxml_analyzer_diff.py
+++ b/tests/test_ooxml_analyzer_diff.py
@@ -1,0 +1,30 @@
+import sys
+import unittest
+from io import StringIO
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.ooxml_analyzer import OOXMLAnalyzer
+
+
+class TestOOXMLAnalyzerDiff(unittest.TestCase):
+    def test_print_diff_output(self):
+        analyzer = OOXMLAnalyzer('dummy.pptx')
+        original = {'a': 1, 'b': 2}
+        processed = {'a': 1, 'b': 3, 'c': 4}
+        captured = StringIO()
+        stdout = sys.stdout
+        try:
+            sys.stdout = captured
+            analyzer.print_diff(original, processed)
+        finally:
+            sys.stdout = stdout
+        output = captured.getvalue()
+        self.assertIn('-  "b": 2', output)
+        self.assertIn('+  "b": 3,', output)
+        self.assertIn('+  "c": 4', output)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `print_diff` method to generate unified diffs between OOXML analyses
- expose `--show-diff` flag in CLI for comparison mode
- add unit test covering diff output

## Testing
- `PYTHONPATH=. pytest tests/test_ooxml_analyzer_diff.py -q`
- `PYTHONPATH=. pytest tests/test_template_analyzer_simple.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cbb35bf483208bc45dc1876f8a92