### PR TITLE
Handle unresolved token references and circular loops

### DIFF
--- a/tests/test_token_resolver_unresolved.py
+++ b/tests/test_token_resolver_unresolved.py
@@ -1,0 +1,26 @@
+import pytest
+import sys
+from pathlib import Path
+
+# Ensure repository root is in path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.token_resolver import TokenResolver
+
+
+def test_detect_circular_reference():
+    resolver = TokenResolver()
+    tokens = {"a": "{b}", "b": "{a}"}
+    with pytest.raises(ValueError) as exc:
+        resolver.resolve_token_references(tokens)
+    assert "Circular token reference" in str(exc.value)
+
+
+def test_report_unresolved_tokens():
+    resolver = TokenResolver()
+    tokens = {"a": "{missing}"}
+    with pytest.raises(ValueError) as exc:
+        resolver.resolve_token_references(tokens)
+    message = str(exc.value)
+    assert "Unresolved token references" in message
+    assert "a" in message or "missing" in message


### PR DESCRIPTION
## Summary
- track unresolved token references in TokenResolver
- detect circular token dependencies to prevent infinite loops
- surface unresolved tokens during CLI failures and add regression tests

## Testing
- `pytest tests/test_token_resolver_unresolved.py -q`
- `pytest -q` *(fails: NameError: JSONPatchProcessor is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c0cd6ea3488320b9ae65a8d94ba95a