### PR TITLE
Validate design tokens against schema

### DIFF
--- a/tests/test_token_schema_validation.py
+++ b/tests/test_token_schema_validation.py
@@ -1,0 +1,66 @@
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError
+
+import sys
+
+# Ensure repository root is in path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from tools.token_resolver import TokenResolver
+
+
+def _prepare_schema(tmp_tokens_dir: Path) -> None:
+    schema_src = Path(__file__).resolve().parents[1] / "tokens" / "schema" / "design-tokens.schema.json"
+    schema_dst_dir = tmp_tokens_dir / "schema"
+    schema_dst_dir.mkdir(parents=True)
+    shutil.copy(schema_src, schema_dst_dir / "design-tokens.schema.json")
+
+
+def test_load_core_tokens_valid(tmp_path: Path) -> None:
+    tokens_dir = tmp_path
+    _prepare_schema(tokens_dir)
+    core_dir = tokens_dir / "core"
+    core_dir.mkdir()
+    valid_tokens = {
+        "$schema": "https://stylestack.dev/schemas/design-tokens.schema.json",
+        "colors": {
+            "primary": {
+                "value": "#FFFFFF",
+                "type": "color",
+                "description": "White color",
+            }
+        },
+    }
+    with open(core_dir / "valid.json", "w") as f:
+        json.dump(valid_tokens, f)
+
+    resolver = TokenResolver()
+    loaded = resolver.load_core_tokens(tokens_dir)
+    assert loaded["colors"]["primary"]["value"] == "#FFFFFF"
+
+
+def test_load_core_tokens_invalid(tmp_path: Path) -> None:
+    tokens_dir = tmp_path
+    _prepare_schema(tokens_dir)
+    core_dir = tokens_dir / "core"
+    core_dir.mkdir()
+    invalid_tokens = {
+        "$schema": "https://stylestack.dev/schemas/design-tokens.schema.json",
+        "colors": {
+            "primary": {
+                "value": "#FFFFFF"
+                # Missing required 'type'
+            }
+        },
+    }
+    with open(core_dir / "invalid.json", "w") as f:
+        json.dump(invalid_tokens, f)
+
+    resolver = TokenResolver()
+    with pytest.raises(ValidationError):
+        resolver.load_core_tokens(tokens_dir)
+

--- a/tokens/schema/design-tokens.schema.json
+++ b/tokens/schema/design-tokens.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StyleStack Design Tokens",
+  "description": "Schema for StyleStack hierarchical design tokens",
+  "type": "object",
+  "properties": {
+    "$schema": {"type": "string"}
+  },
+  "patternProperties": {
+    "^[a-zA-Z0-9._-]+$": {
+      "oneOf": [
+        {"$ref": "#/definitions/token"},
+        {"$ref": "#/definitions/tokenGroup"}
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "token": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The actual token value"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "color",
+            "dimension",
+            "fontFamily",
+            "fontWeight",
+            "duration",
+            "cubicBezier",
+            "number",
+            "typography",
+            "shadow",
+            "gradient",
+            "transition",
+            "string"
+          ],
+          "description": "Token type following W3C spec"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human readable description"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Tool-specific extensions",
+          "properties": {
+            "stylestack": {
+              "type": "object",
+              "properties": {
+                "emu": {
+                  "type": "number",
+                  "description": "EMU value for OOXML precision"
+                },
+                "contrast": {
+                  "type": "number",
+                  "description": "WCAG contrast ratio"
+                },
+                "category": {
+                  "type": "string",
+                  "enum": [
+                    "primitive",
+                    "semantic",
+                    "component"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": ["value", "type"],
+      "additionalProperties": false
+    },
+    "tokenGroup": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "oneOf": [
+            {"$ref": "#/definitions/token"},
+            {"$ref": "#/definitions/tokenGroup"}
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- validate core design token files against tokens/schema/design-tokens.schema.json
- add local design token schema and tests for valid/invalid token files

## Testing
- `pytest tests/test_token_schema_validation.py -q`
- `pytest tests/test_json_token_parser.py::TestJSONTokenParser::test_load_json_token_file -q` *(fails: ModuleNotFoundError: No module named 'tools')*

------
https://chatgpt.com/codex/tasks/task_e_68c0cd3059348320a3c5f1965be64a4a