### PR TITLE
feat(tokens): add table token definitions

### DIFF
--- a/tokens/core/base.json
+++ b/tokens/core/base.json
@@ -11,5 +11,6 @@
   "grid": {
     "line_height": 17,
     "font_size": 24
-  }
+  },
+  "table": "{table.default}"
 }

--- a/tokens/core/table.json
+++ b/tokens/core/table.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://stylestack.dev/schemas/design-tokens.schema.json",
+  "table": {
+    "default": {
+      "value": {
+        "styleId": "TableNormal",
+        "width": "100%",
+        "alignment": "center",
+        "margins": {
+          "top": "{space.2}",
+          "bottom": "{space.2}",
+          "left": "{space.2}",
+          "right": "{space.2}"
+        },
+        "border": {
+          "color": "{colors.gray.200}",
+          "width": "1pt"
+        }
+      },
+      "type": "table",
+      "description": "Default table styling for documents",
+      "$extensions": {
+        "stylestack": {
+          "category": "semantic"
+        }
+      }
+    }
+  }
+}

--- a/tokens/schema/token.schema.json
+++ b/tokens/schema/token.schema.json
@@ -22,7 +22,8 @@
             "typography",
             "shadow",
             "gradient",
-            "transition"
+            "transition",
+            "table",
           ],
           "description": "Token type following W3C spec"
         },
@@ -126,6 +127,36 @@
         "offsetY",
         "blur"
       ]
+    },
+    "table": {
+      "type": "object",
+      "properties": {
+        "styleId": { "type": "string" },
+        "width": { "type": "string" },
+        "alignment": {
+          "type": "string",
+          "enum": ["left", "center", "right"]
+        },
+        "margins": {
+          "type": "object",
+          "properties": {
+            "top": { "type": "string" },
+            "bottom": { "type": "string" },
+            "left": { "type": "string" },
+            "right": { "type": "string" }
+          },
+          "required": ["top", "bottom", "left", "right"]
+        },
+        "border": {
+          "type": "object",
+          "properties": {
+            "color": { "type": "string" },
+            "width": { "type": "string" }
+          },
+          "required": ["color"]
+        }
+      },
+      "required": ["styleId"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add table design tokens for default styling
- extend token schema with table type and structure
- reference default table tokens in base design tokens

## Testing
- `pytest` *(fails: NameError: JSONPatchProcessor is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d0ac65ac832081c104a6a7912697