### PR TITLE
Add removable table placeholders for Word and Excel templates

### DIFF
--- a/baseline-templates/minimal-excel-a4-worksheet.xml
+++ b/baseline-templates/minimal-excel-a4-worksheet.xml
@@ -4,7 +4,31 @@
     <sheetView workbookViewId="0"/>
   </sheetViews>
   <sheetFormatPr defaultRowHeight="12.75"/>
-  <sheetData/>
+  <cols>
+    <col min="1" max="1" width="{{table.column1.width}}" customWidth="1"/>
+    <col min="2" max="2" width="{{table.column2.width}}" customWidth="1"/>
+    <col min="3" max="3" width="{{table.column3.width}}" customWidth="1"/>
+  </cols>
+  <sheetData>
+    <!-- TABLE_PLACEHOLDER_START -->
+    <!-- XPath: /x:worksheet/x:sheetData/x:row -->
+    <row r="1">
+      <c r="A1" t="inlineStr"><is><t>{{content.header.cell1}}</t></is></c>
+      <c r="B1" t="inlineStr"><is><t>{{content.header.cell2}}</t></is></c>
+      <c r="C1" t="inlineStr"><is><t>{{content.header.cell3}}</t></is></c>
+    </row>
+    <row r="2">
+      <c r="A2" t="inlineStr"><is><t>{{content.data.row2.cell1}}</t></is></c>
+      <c r="B2" t="inlineStr"><is><t>{{content.data.row2.cell2}}</t></is></c>
+      <c r="C2" t="inlineStr"><is><t>{{content.data.row2.cell3}}</t></is></c>
+    </row>
+    <row r="3">
+      <c r="A3" t="inlineStr"><is><t>{{content.data.row3.cell1}}</t></is></c>
+      <c r="B3" t="inlineStr"><is><t>{{content.data.row3.cell2}}</t></is></c>
+      <c r="C3" t="inlineStr"><is><t>{{content.data.row3.cell3}}</t></is></c>
+    </row>
+    <!-- TABLE_PLACEHOLDER_END -->
+  </sheetData>
   <pageMargins left="0.85" right="0.85" top="1.06" bottom="1.06" header="0.43" footer="0.43"/>
   <pageSetup paperSize="9" orientation="portrait" horizontalDpi="300" verticalDpi="300"/>
   <headerFooter>

--- a/baseline-templates/minimal-word-a4-document.xml
+++ b/baseline-templates/minimal-word-a4-document.xml
@@ -1,6 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:body>
+    <!-- TABLE_PLACEHOLDER_START -->
+    <!-- XPath: /w:document/w:body/w:tbl[1] -->
+    <w:tbl>
+      <w:tblPr>
+        <w:tblStyle w:val="{{table.style.id}}"/>
+        <w:tblW w:w="{{table.width.dxa}}" w:type="dxa"/>
+      </w:tblPr>
+      <w:tblGrid>
+        <w:gridCol w:w="{{table.column1.width}}"/>
+        <w:gridCol w:w="{{table.column2.width}}"/>
+        <w:gridCol w:w="{{table.column3.width}}"/>
+      </w:tblGrid>
+      <w:tr>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column1.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.header.cell1}}</w:t></w:r></w:p></w:tc>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column2.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.header.cell2}}</w:t></w:r></w:p></w:tc>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column3.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.header.cell3}}</w:t></w:r></w:p></w:tc>
+      </w:tr>
+      <w:tr>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column1.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.data.row2.cell1}}</w:t></w:r></w:p></w:tc>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column2.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.data.row2.cell2}}</w:t></w:r></w:p></w:tc>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column3.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.data.row2.cell3}}</w:t></w:r></w:p></w:tc>
+      </w:tr>
+      <w:tr>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column1.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.data.row3.cell1}}</w:t></w:r></w:p></w:tc>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column2.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.data.row3.cell2}}</w:t></w:r></w:p></w:tc>
+        <w:tc><w:tcPr><w:tcW w:w="{{table.column3.width}}" w:type="dxa"/></w:tcPr><w:p><w:r><w:t>{{content.data.row3.cell3}}</w:t></w:r></w:p></w:tc>
+      </w:tr>
+    </w:tbl>
+    <!-- TABLE_PLACEHOLDER_END -->
     <w:sectPr>
       <w:pgSz w:w="11906" w:h="16838" w:code="9"/>
       <w:pgMar w:top="85" w:right="68" w:bottom="85" w:left="68" w:header="34" w:footer="34" w:gutter="0"/>


### PR DESCRIPTION
## Summary
- add 3×3 token-driven table placeholder to minimal Word and Excel A4 templates with XPath documentation
- support optional removal of table placeholders in TemplatePatcher and OOXMLProcessor

## Testing
- `pytest tests/test_ooxml_processor.py -q` *(fails: test_word_document_processing, test_excel_styles_processing)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d0a0fe2883209059eb1747cca38a